### PR TITLE
Remove # from naming convertion

### DIFF
--- a/lib/color/ColorButton.js
+++ b/lib/color/ColorButton.js
@@ -78,8 +78,9 @@ var _default = function (_Component) {
 
       var currentStyle = editorState.getCurrentInlineStyle();
       if (!currentStyle.has(color)) {
-        console.log(color);
-        var newState = _draftJs.RichUtils.toggleInlineStyle(editorState, 'color-' + color);
+        // console.log(color)
+        var safeName = color.replace('#', '');
+        var newState = _draftJs.RichUtils.toggleInlineStyle(editorState, 'color-' + safeName);
         onChange(newState);
         this.setState({ showModal: false });
       }

--- a/src/color/ColorButton.js
+++ b/src/color/ColorButton.js
@@ -31,8 +31,9 @@ export default class extends Component {
 
     const currentStyle = editorState.getCurrentInlineStyle()
     if (!currentStyle.has(color)) {
-      console.log(color)
-      const newState = RichUtils.toggleInlineStyle(editorState, `color-${color}`)
+      // console.log(color)
+      const safeName = color.replace('#', '');
+      const newState = RichUtils.toggleInlineStyle(editorState, `color-${safeName}`);
       onChange(newState)
       this.setState({ showModal: false })
     }


### PR DESCRIPTION
By removing # from color name makes it into a valid css class. 
```js
const safeName = color.replace('#', '');
const newState = RichUtils.toggleInlineStyle(editorState, `color-${safeName}`);
```

This means inside the `convert.js` in Last Draft, we can map these styles to class allowing the reload of classes from html.
```js
// In Last Draft
htmlToStyle: (nodeName, node, currentStyle) => {
      if (node.className !== undefined) {
       // remaps the color-000000 class back into a draft style
        return currentStyle.add(node.className)
      } else {
        return currentStyle
      }
    },
```
I will be sending a pull request to Last Draft as well with the convert changes ;)